### PR TITLE
Resolve Issue #2 and related bugs

### DIFF
--- a/workflows/__init__.py
+++ b/workflows/__init__.py
@@ -1,4 +1,4 @@
 """Initialize the app"""
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 __title__ = "Onboarding"

--- a/workflows/management/commands/onboarding_sync_assignments.py
+++ b/workflows/management/commands/onboarding_sync_assignments.py
@@ -1,0 +1,16 @@
+from django.contrib.contenttypes.models import ContentType
+from django.core.management.base import BaseCommand
+
+from ...models import Wizard, ActionItem
+from ...signals import filters
+from django.contrib.auth.models import User
+
+class Command(BaseCommand):
+    help = 'Syncing all the Models from Secure Group Filters'
+
+    def handle(self, *args, **options):
+        self.stdout.write("Syncing all task assignments")
+        for w in Wizard.objects.filter(auto_assigned = True):
+            for user in w.users:
+                if not w.is_complete(user):
+                    ActionItem.objects.update_or_create(user=user,wizard=w)

--- a/workflows/models.py
+++ b/workflows/models.py
@@ -154,11 +154,17 @@ class Wizard(models.Model):
     )
     
     steps = SortedManyToManyField(Step)
-    
+
+    @property
+    def configured_visibility(self):
+        return self.states.exists() or self.groups.exists() or self.corporations.exists() or self.alliances.exists() or self.factions.exists() or self.characters.exists()
+
     @property
     def users(self):
         state_users = User.objects.filter(profile__state__in=self.states.all())
         group_users = User.objects.filter(groups__in=self.groups.all())
+        char_users = User.objects.filter(character_ownerships__character__in=self.characters.all())
+
 
         corp_ids = []
         for corp in self.corporations.all():
@@ -176,7 +182,7 @@ class Wizard(models.Model):
             faction_ids.append(faction.faction_id)
         faction_users = User.objects.filter(character_ownerships__character__faction_id__in=faction_ids)
         
-        return state_users | group_users | corp_users | alliance_users | faction_users
+        return state_users | group_users | corp_users | alliance_users | faction_users | char_users
 
     def is_complete(self, user: User):
         result = True

--- a/workflows/signals.py
+++ b/workflows/signals.py
@@ -33,8 +33,8 @@ def _update_action_items(user: User):
 
     assigned_wizards = Wizard.objects.get_user_assigned_wizards(user, True)
     for w in assigned_wizards.all():
-        if user not in w.users:
-            ActionItem.objects.filter(wizard=w).delete()
+        if not w.configured_visibility and user not in w.users:
+            ActionItem.objects.filter(user=user,wizard=w).delete()
 
     new_wizards = Wizard.objects.get_user_autoassigned_wizards(user)
     for w in new_wizards.all():


### PR DESCRIPTION
## Description

Fixes all assignments for a wizard being wiped on signal triggers, users being unable to see wizards that they should be able to see when character assignments are used, and adds manage.py command to forcibly re-sync assigned wizards (onboarding_sync_assignments).

Fixes #2

## Type of change

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
